### PR TITLE
:bug: 修复请求头 token、配置键匹配、输出路径与依赖声明等问题

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ requires-python = ">=3.10,<4.0"
 poetry-plugin-export = ">=1.8"
 
 [tool.poetry.dependencies]
+gradio-client = "^1.0.0"
+numpy = "^2.0.0"
+pandas = "^2.0.0"
+Pillow = "^11.0.0"
+rich = "^14.0.0"
 python = "^3.10"
 gradio = "^5.49.1"
 ujson = "^5.11.0"

--- a/src/generate_images.py
+++ b/src/generate_images.py
@@ -382,7 +382,7 @@ def main(
                         json_data,
                         strength=return_strength(magnitude),
                         noise=0,
-                        image=image_to_base64(resize_image(path)),
+                        image=image_to_base64(resize_image(path, output_path="./outputs/temp_enhance_resized.png")),
                         extra_noise_seed=_seed,
                         color_correct=False,
                     )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,6 +7,7 @@ import re
 import secrets
 import shutil
 import smtplib
+import string
 import subprocess
 import sys
 import time
@@ -40,7 +41,7 @@ from utils.naimeta import inject_data
 
 def generate_random_str(randomlength):
     random_str = ""
-    base_str = "ABCDEFGHIGKLMNOPQRSTUVWXYZabcdefghigklmnopqrstuvwxyz0123456789"
+    base_str = string.ascii_letters + string.digits
     length = len(base_str) - 1
     for i in range(randomlength):
         random_str += base_str[random.randint(0, length)]

--- a/utils/generator.py
+++ b/utils/generator.py
@@ -11,7 +11,7 @@ from utils import generate_random_str
 from utils.environment import env
 from utils.errors import NovelAIAPIError
 from utils.logger import logger, loguru_to_rich
-from utils.models.headers import headers
+from utils.models.headers import build_headers
 from utils.variable import proxies
 
 ANLAS = -1
@@ -23,7 +23,7 @@ def inquire_anlas():
     try:
         rep = requests.get(
             "https://api.novelai.net/user/subscription",
-            headers=headers,
+            headers=build_headers(),
             proxies=proxies,
             timeout=30,
         )
@@ -58,6 +58,10 @@ def _safe_output_path(image_type, seed):
     base_path += ".png"
 
     target = Path(base_path).resolve()
+    outputs_root = Path("./outputs").resolve()
+    if not target.is_relative_to(outputs_root):
+        logger.warning(f"输出路径超出 outputs 目录，已回退到默认路径: {target}")
+        target = Path(f"./outputs/{image_type}/{date.today()}/{seed}_{generate_random_str(6)}.png").resolve()
     target.parent.mkdir(parents=True, exist_ok=True)
 
     return target
@@ -74,7 +78,7 @@ class Generator:
         rep = requests.post(
             url=self.url,
             json=json_data,
-            headers=headers,
+            headers=build_headers(),
             proxies=proxies,
             timeout=30,
         )

--- a/utils/image_tools.py
+++ b/utils/image_tools.py
@@ -91,7 +91,7 @@ def is_fully_transparent(image_path):
     return np.all(alpha_channel == 0)
 
 
-def resize_image(image_path):
+def resize_image(image_path, output_path=None):
     with Image.open(image_path) as image:
         w, h = image.size
         nw, nh = return_x64(w), return_x64(h)
@@ -101,8 +101,8 @@ def resize_image(image_path):
             nh = nh - 64 if nh > 64 else nh
         new_size = (nw, nh)
         image = image.resize(new_size, Image.Resampling.LANCZOS)
-        image.save(image_path)
-    return image_path
+        image.save(output_path or image_path)
+    return output_path or image_path
 
 
 def process_white_regions(image_path, output_path):

--- a/utils/models/headers.py
+++ b/utils/models/headers.py
@@ -1,20 +1,26 @@
 from utils.environment import env
 from utils.logger import logger
 
-headers = {
-    "Accept": "*/*",
-    "Accept-Encoding": "gzip, deflate, br",
-    "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6",
-    "Authorization": f"Bearer {env.token if env.token else logger.error('未配置 Token!')}",
-    "Content-type": "application/json",
-    "Origin": "https://novelai.net",
-    "Priority": "u=1, i",
-    "Referer": "https://novelai.net/",
-    "Sec-Ch-Ua": '"Not(A:Brand";v="99", "Microsoft Edge";v="133", "Chromium";v="133"',
-    "Sec-Ch-Ua-mobile": "?0",
-    "Sec-Ch-Ua-Platform": '"Windows"',
-    "Sec-Fetch-Dest": "empty",
-    "Sec-Fetch-Mode": "cors",
-    "Sec-Fetch-Site": "same-site",
-    "User-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36",
-}
+
+def build_headers():
+    token = env.token
+    if not token:
+        logger.error("未配置 Token!")
+
+    return {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6",
+        "Authorization": f"Bearer {token}" if token else "",
+        "Content-type": "application/json",
+        "Origin": "https://novelai.net",
+        "Priority": "u=1, i",
+        "Referer": "https://novelai.net/",
+        "Sec-Ch-Ua": '"Not(A:Brand";v="99", "Microsoft Edge";v="133", "Chromium";v="133"',
+        "Sec-Ch-Ua-mobile": "?0",
+        "Sec-Ch-Ua-Platform": '"Windows"',
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36",
+    }

--- a/utils/setting_updater.py
+++ b/utils/setting_updater.py
@@ -9,7 +9,7 @@ def _modify_env(**kwargs: dict):
             lines = f.readlines()
             f.seek(0)
             setting = f.read()
-        if target_key not in setting:
+        if not any(line.split("=", 1)[0].strip() == target_key for line in setting.splitlines()):
             with open(".env", "w", encoding="utf-8") as f:
                 f.write(setting + f"\n{target_key}={new_value}\n")
         else:


### PR DESCRIPTION
## 简介

代码审查中发现并修复了几处独立的、低风险的问题。每个改动都尽量做到最小,已通过 `ruff` / `black` / `isort`(line-length 120)。

## 改动内容

### 🐛 Bug 修复
- **请求头 token (`utils/models/headers.py` + `utils/generator.py`)**:原先 `headers` 是模块导入期求值的常量,且 `Bearer {token if token else logger.error(...)}` 在 token 为空时会拼出字面量 `"Bearer None"`(把日志副作用塞进了表达式)。改为运行期 `build_headers()`:token 缺失时正常报错且 `Authorization` 不带值;同时在 WebUI 里改完 token 无需重启即可生效。

- **`.env` 配置写入 (`utils/setting_updater.py`)**:`_modify_env` 用 `if target_key not in setting`(对整个文件文本做子串判断)来决定键是否存在。由于 `token` 是 `smtp_token` 的子串,会被误判为已存在而进入更新分支,最终可能静默丢失该配置项。改为逐行精确匹配键名。

- **随机字符集 (`utils/__init__.py`)**:`generate_random_str` 的 `base_str` 写错了——`"...HIGK..."` 漏了 `J`/`j` 且 `G`/`g` 重复。改用 `string.ascii_letters + string.digits`。

- **输出路径越界 (`utils/generator.py`)**:`_safe_output_path` 对用户自填的 `custom_path` 没有做约束,`../` 可能写到 `./outputs` 之外。增加 `is_relative_to(./outputs)` 校验,越界时告警并回退到安全的默认路径。

- **Enhance 覆盖成品图 (`utils/image_tools.py` + `src/generate_images.py`)**:`resize_image` 会原地 `save(image_path)`;在 enhance 流程里传入的是已落盘的成品图,导致磁盘上的原图被缩放覆盖。给 `resize_image` 增加可选 `output_path` 参数(默认仍原地保存,不影响其它临时文件调用方),enhance 改为输出到临时文件,不再破坏原成品图。

### 📦 依赖
- **`pyproject.toml`**:代码直接 `import` 了 `numpy` / `pandas` / `PIL` / `rich` / `gradio_client`,此前只靠 `gradio` 的传递依赖兜底。将其补为直接依赖(`PIL` 对应 PyPI 包名 `Pillow`),版本约束与现有 stack(gradio 5.49)实际解析结果一致。

## 测试
- `python -m py_compile` 全部通过
- `ruff check` / `black --check` / `isort --check-only` 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)