### PR TITLE
:lock: 默认不再向 WebUI 暴露整个文件系统

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,4 @@ skip_inquire_anlas=False
 smtp_num=0
 smtp_mail=""
 smtp_token=""
+allow_full_disk_access=False

--- a/main.py
+++ b/main.py
@@ -1271,7 +1271,14 @@ with gr.Blocks(
 
 
 if env.allow_full_disk_access:
-    allowed_paths = [f"{d}:" for d in string.ascii_uppercase if Path(f"{d}:").exists()]
+    allowed_paths = []
+    for drive_letter in string.ascii_uppercase:
+        try:
+            if Path(f"{drive_letter}:").exists():
+                allowed_paths.append(f"{drive_letter}:")
+        except OSError:
+            # 跳过无法识别的卷 (如双系统的 Linux 分区、空读卡器等)
+            continue
     logger.warning("allow_full_disk_access 已开启: WebUI 可读取本机所有盘符的文件!")
     if env.share:
         logger.warning("危险: share=True 且开启全盘访问, 任何拿到公开链接的人都能下载本机任意文件! 强烈建议关闭其一。")

--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ from utils.components import (
 )
 from utils.environment import env
 from utils.image_tools import return_array_image
+from utils.logger import logger
 from utils.prepare import _model, is_updated, last_data, parameters
 from utils.setting_updater import modify_env
 from utils.variable import (
@@ -1269,10 +1270,18 @@ with gr.Blocks(
     sampler.change(update_components_for_sampler_change, inputs=sampler, outputs=[noise_schedule, sm])
 
 
+if env.allow_full_disk_access:
+    allowed_paths = [f"{d}:" for d in string.ascii_uppercase if Path(f"{d}:").exists()]
+    logger.warning("allow_full_disk_access 已开启: WebUI 可读取本机所有盘符的文件!")
+    if env.share:
+        logger.warning("危险: share=True 且开启全盘访问, 任何拿到公开链接的人都能下载本机任意文件! 强烈建议关闭其一。")
+else:
+    allowed_paths = [os.path.abspath("./outputs")]
+
 anr.launch(
     inbrowser=True,
     share=env.share,
     server_port=env.port,
     favicon_path="./assets/logo.ico",
-    allowed_paths=[f"{d}:" for d in string.ascii_uppercase if Path(f"{d}:").exists()],
+    allowed_paths=allowed_paths,
 )

--- a/utils/environment.py
+++ b/utils/environment.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     smtp_num: int = 0
     smtp_mail: Union[str, None] = None
     smtp_token: Union[str, None] = None
+    allow_full_disk_access: bool = False
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow", arbitrary_types_allowed=True)
 


### PR DESCRIPTION
## 问题

`main.py` 的 `anr.launch(...)` 把本机所有存在的盘符根目录加入了 Gradio 的 `allowed_paths`:

```python
allowed_paths=[f"{d}:" for d in string.ascii_uppercase if Path(f"{d}:").exists()]
```

这等于允许 Gradio 的 `/file=` 端点读取并下发本机**任意文件**;而 `launch()` 没有设置 `auth=`。其影响:

- 本地模式下,任何能访问该端口的页面/程序都可能通过 `/file=` 读取任意文件;
- 一旦开启配置项 `share=True`(Gradio 生成有效期一周的公网链接),**任何拿到链接的人都能下载这台机器上任意盘符的任意文件**——包括 `.env` 里的 NovelAI token、私钥、个人文档等。

## 改动

- 默认仅把 `./outputs` 加入 `allowed_paths`;
- 新增配置项 `allow_full_disk_access`(默认 `False`):仅在用户显式开启时才恢复"全盘访问"的原行为,并打印警告;若同时开启 `share`,再追加一条强警告;
- `.env.example` 增加对应项。

这样默认安全,需要"任意目录读图/批处理"等功能的本地用户仍可显式开启,行为可控。

> 说明:`图片筛选 / 超分 / 导演工具` 等按目录读图的功能,如果目标目录在 `./outputs` 之外,需要把 `allow_full_disk_access` 设为 `True`。如果你希望保留这些功能默认可用,也可以讨论改成"按需把用户输入的目录动态加入 allowed_paths"的方案。

## 测试
- `python -m py_compile` 通过
- `ruff check` / `black --check` / `isort --check-only` 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)